### PR TITLE
Changed endpoint urls to https as it is required by the Flickr API

### DIFF
--- a/flickr.go
+++ b/flickr.go
@@ -13,9 +13,9 @@ import (
 )
 
 const (
-	endpoint        = "http://api.flickr.com/services/rest/?"
-	uploadEndpoint  = "http://api.flickr.com/services/upload/"
-	replaceEndpoint = "http://api.flickr.com/services/replace/"
+	endpoint        = "https://api.flickr.com/services/rest/?"
+	uploadEndpoint  = "https://api.flickr.com/services/upload/"
+	replaceEndpoint = "https://api.flickr.com/services/replace/"
 	apiHost         = "api.flickr.com"
 )
 


### PR DESCRIPTION
This PR changes the API urls  from http to https as this is the only supported way of using the Flickr API soon (http://code.flickr.net/2014/04/30/flickr-api-going-ssl-only-on-june-27th-2014/). Otherwise each API Call fails. I provide this PR, as the Flickr page points to your Repo, so it should work without changes.

Philipp
