### PR TITLE
Fix panic, use standard errors package and return more errors.

### DIFF
--- a/flickr.go
+++ b/flickr.go
@@ -214,8 +214,11 @@ func sendPost(postRequest *http.Request) (response *Response, err error) {
 	if err != nil {
 		return nil, err
 	}
-	rawBody, _ := ioutil.ReadAll(resp.Body)
+	rawBody, err := ioutil.ReadAll(resp.Body)
 	resp.Body.Close()
+	if err != nil {
+		return nil, err
+	}
 
 	var r Response
 	err = xml.Unmarshal(rawBody, &r)

--- a/flickr.go
+++ b/flickr.go
@@ -46,8 +46,15 @@ func (nopCloser) Close() error { return nil }
 
 var ErrNeedBothAPIKeyAndMethod = errors.New("Need both API key and method")
 
+func (request *Request) GetArgs() map[string]string {
+	if request.Args == nil {
+		request.Args = make(map[string]string)
+	}
+	return request.Args
+}
+
 func (request *Request) Sign(secret string) {
-	args := request.Args
+	args := request.GetArgs()
 
 	// Remove api_sig
 	delete(args, "api_sig")
@@ -84,7 +91,7 @@ func (request *Request) Sign(secret string) {
 }
 
 func (request *Request) URL() string {
-	args := request.Args
+	args := request.GetArgs()
 
 	args["api_key"] = request.ApiKey
 	args["method"] = request.Method
@@ -140,13 +147,14 @@ func (request *Request) buildPost(url_ string, filename string, filetype string)
 	}
 	f_size := stat.Size()
 
-	request.Args["api_key"] = request.ApiKey
+	args := request.GetArgs()
+	args["api_key"] = request.ApiKey
 
 	boundary, end := "----###---###--flickr-go-rules", "\r\n"
 
 	// Build out all of POST body sans file
 	header := bytes.NewBuffer(nil)
-	for k, v := range request.Args {
+	for k, v := range args {
 		header.WriteString("--" + boundary + end)
 		header.WriteString("Content-Disposition: form-data; name=\"" + k + "\"" + end + end)
 		header.WriteString(v + end)

--- a/flickr.go
+++ b/flickr.go
@@ -108,10 +108,10 @@ func (request *Request) Execute() (response string, ret error) {
 	s := request.URL()
 
 	res, err := http.Get(s)
-	defer res.Body.Close()
 	if err != nil {
 		return "", err
 	}
+	defer res.Body.Close()
 
 	body, _ := ioutil.ReadAll(res.Body)
 	return string(body), nil

--- a/flickr.go
+++ b/flickr.go
@@ -79,12 +79,8 @@ func (request *Request) Sign(secret string) {
 	delete(args, "api_key")
 	delete(args, "method")
 
-	// Have the full string, now hash
-	hash := md5.New()
-	hash.Write([]byte(s))
-
 	// Add api_sig as one of the args
-	args["api_sig"] = fmt.Sprintf("%x", hash.Sum(nil))
+	args["api_sig"] = fmt.Sprintf("%x", md5.Sum([]byte(s)))
 }
 
 func (request *Request) URL() string {

--- a/flickr.go
+++ b/flickr.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"crypto/md5"
 	"encoding/xml"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -43,11 +44,7 @@ type nopCloser struct {
 
 func (nopCloser) Close() error { return nil }
 
-type Error string
-
-func (e Error) Error() string {
-	return string(e)
-}
+var ErrNeedBothAPIKeyAndMethod = errors.New("Need both API key and method")
 
 func (request *Request) Sign(secret string) {
 	args := request.Args
@@ -102,7 +99,7 @@ func (request *Request) URL() string {
 
 func (request *Request) Execute() (response string, ret error) {
 	if request.ApiKey == "" || request.Method == "" {
-		return "", Error("Need both API key and method")
+		return "", ErrNeedBothAPIKeyAndMethod
 	}
 
 	s := request.URL()

--- a/flickr.go
+++ b/flickr.go
@@ -131,7 +131,10 @@ func encodeQuery(args map[string]string) string {
 }
 
 func (request *Request) buildPost(url_ string, filename string, filetype string) (*http.Request, error) {
-	real_url, _ := url.Parse(url_)
+	real_url, err := url.Parse(url_)
+	if err != nil {
+		return nil, err
+	}
 
 	f, err := os.Open(filename)
 	if err != nil {

--- a/flickr.go
+++ b/flickr.go
@@ -113,8 +113,8 @@ func (request *Request) Execute() (response string, ret error) {
 	}
 	defer res.Body.Close()
 
-	body, _ := ioutil.ReadAll(res.Body)
-	return string(body), nil
+	body, err := ioutil.ReadAll(res.Body)
+	return string(body), err
 }
 
 func encodeQuery(args map[string]string) string {


### PR DESCRIPTION
Hello,
I was using the library for a simple automated update tool and I got a panic when my network failed! It was due to a defer being placed before an error check had been made. I've corrected that (
6d9da4a), and also tidied a few things up:
Return errors returned by ioutil.ReadAll -- fb33db4, 6d9da4a
Use standard errors package for error -- c6b684f
Use md5.Sum (it's tidier) -- 19e52cd
Return errors from url.Parse -- c380603
Thanks,
Jacob